### PR TITLE
Change high treasury time threshold

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -605,7 +605,7 @@ async function run() {
     if (day >= 12) {
       return "55ffff"; // Very High
     }
-    if (day >= 4) {
+    if (day >= 5) {
       return "55ff55"; // High
     }
     if (day >= 1) {


### PR DESCRIPTION
A territory takes 5d to get high treasury and not 4.